### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,8 @@
 name: E2E
 
 on: deployment_status
+permissions:
+  contents: read
 
 jobs:
   cypress:


### PR DESCRIPTION
Potential fix for [https://github.com/Bookman0001/nagato/security/code-scanning/2](https://github.com/Bookman0001/nagato/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the job. Since the workflow primarily involves checking out code, setting up Node.js, caching dependencies, and running Cypress tests, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, minimizing security risks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`cypress`) to limit permissions for that job only. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
