### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: auto-test
+permissions:
+  contents: read
 
 on: push
 


### PR DESCRIPTION
Potential fix for [https://github.com/Bookman0001/nagato/security/code-scanning/1](https://github.com/Bookman0001/nagato/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function. Based on the provided steps, the workflow primarily reads repository contents and does not perform any write operations. Therefore, the `contents: read` permission is sufficient.

The `permissions` block should be added immediately after the `name` field in the workflow file. This ensures that the permissions apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
